### PR TITLE
Arcade drive tuning

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -31,9 +31,9 @@ public class Constants
         public static final double KD = 0.0;
         public static final double CLOSED_LOOP_RAMP = 0.5;
         public static final double MAX_VELOCITY = 21549;
-        public static final double DEFAULT_MAX_VELOCITY_PERCENTAGE = 0.75;
-        public static final double DEFAULT_MAX_TURNING_SPEED = 0.65;
-        public static final double VELOCITY_SLOWDOWN_MODIFIER = 0.25;
+        public static final double DEFAULT_MAX_VELOCITY_PERCENTAGE = 0.6d;
+        public static final double DEFAULT_MAX_TURNING_SPEED = 0.5d;
+        public static final double VELOCITY_SLOWDOWN_MODIFIER = 0.25d;
         public static final int LEFT_LEAD_TALON_CAN_ID = 0;
         public static final int LEFT_FOLLOWER_TALON_CAN_ID = 1;
         public static final int RIGHT_LEAD_TALON_CAN_ID = 2;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,6 +46,7 @@ public class Constants
         // MISC Constants
         public static final double WHEEL_CIRCUMFERENCE_FEET = (6.0d/12.0d)*Math.PI; // Wheel diameter 3 in, converting to feet
         public static final double SECONDS_TO_DECISEC = 1.0d/10.0d;
+        public static final double DECISEC_TO_SECONDS = 10.0d/1.0d;
         public static final double GEARBOX_RATIO_TO_ONE = 11.25;
         public static final int ENCODER_COUNTS_PER_REVOLUTION = 2048;
         public static final int ENCODER_EDGES_PER_STEP =  1; 

--- a/src/main/java/frc/robot/classes/SPIKE293Utils.java
+++ b/src/main/java/frc/robot/classes/SPIKE293Utils.java
@@ -28,7 +28,7 @@ public final class SPIKE293Utils
     // Converts from encoder edges per 100 milliseconds to feet per second.
     public static double controllerVelocityToFeetPerSec(double encoderUnits) 
     {
-        return controllerUnitsToFeet(encoderUnits) * SECONDS_TO_DECISEC;
+        return controllerUnitsToFeet(encoderUnits) * DECISEC_TO_SECONDS;
     }
 
     //Converts from feet per second to encoder edges per 100 milliseconds.

--- a/src/main/java/frc/robot/commands/ArcadeDrive.java
+++ b/src/main/java/frc/robot/commands/ArcadeDrive.java
@@ -136,7 +136,7 @@ public class ArcadeDrive extends CommandBase
         speed = MathUtil.clamp(speed, -1.0d, 1.0d);
 
         //Apply limiting percentage
-        turning *= m_velocityLimitPercentage;
+        turning *= m_turningLimitPercentage;
         speed *= m_velocityLimitPercentage;
         arcadeDrive(speed, turning);
     }
@@ -178,12 +178,13 @@ public class ArcadeDrive extends CommandBase
         }
 
         //Convert to encoder velocity
-        double leftMotorSpeed = SPIKE293Utils.percentageToControllerVelocity(leftMotorOutput);
+        //double leftMotorSpeed = SPIKE293Utils.percentageToControllerVelocity(leftMotorOutput);
         // Right needs to be inverted
-        double rightMotorSpeed = SPIKE293Utils.percentageToControllerVelocity(rightMotorOutput *-1.0d);
+        //double rightMotorSpeed = SPIKE293Utils.percentageToControllerVelocity(rightMotorOutput *-1.0d);
 
         //Send to motors
-        m_drivetrain.velocityDrive(leftMotorSpeed, rightMotorSpeed);
+        //m_drivetrain.velocityDrive(leftMotorSpeed, rightMotorSpeed);
+        m_drivetrain.percentDrive(leftMotorOutput, rightMotorOutput * -1.0d);
     }
 
     // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -87,7 +87,9 @@ public class Drivetrain extends SubsystemBase
         rightTalonLead.configClosedloopRamp(CLOSED_LOOP_RAMP);
 
         rightTalonLead.setNeutralMode(NeutralMode.Coast);
+        rightTalonFollower.setNeutralMode(NeutralMode.Coast);
         leftTalonLead.setNeutralMode(NeutralMode.Coast);
+        leftTalonFollower.setNeutralMode(NeutralMode.Coast);
 
         rightTalonLead.configNeutralDeadband(MOTOR_NEUTRAL_DEADBAND);
         rightTalonFollower.configNeutralDeadband(MOTOR_NEUTRAL_DEADBAND);


### PR DESCRIPTION
**Purpose**

The purpose of this PR was to troubleshoot and tweak code based on today's driving trials.

**Description**
As a group, we fixed:

A build issue where drivetrain was set to a new drivetrain. 
- It was fixed by being deleted

Coast Mode
- Both the left and right follow talons were set to coast.

Drive Switch
- Velocity drive was changed to percent drive

Conversion Factor
- A previous conversion factor was changed and now goes from deci-second to seconds instead of going the opposite way around. The velocity was off by a factor of 10, but now is back to normal

Speed Change
- New Max Velocity is 0.60
- New Max Turning speed in 0.50
- Slow Modifier is 0.25


Testing
Currently, this code builds and has been tested during today's trials.